### PR TITLE
scripted_functions: accept more than 1 condition block

### DIFF
--- a/common/scripted_functions.cwt
+++ b/common/scripted_functions.cwt
@@ -6,7 +6,7 @@ types = {
 }
 
 scripted_function = {
-	## cardinality = 0..1
+	## cardinality = 0..inf
 	condition = {
 		## cardinality = 0..1
 		tooltip = localisation


### PR DESCRIPTION
The following is completely valid:

```
can_increase_stability = {
	condition = {
		tooltip = "ab_frankish_crisis_cant_stab"
		potential = {
			tag = FRC
		}
		allow = {
			OR = {
				has_country_flag = had_frankish_succession_crisis
				has_disaster = frankish_succession_crisis
			}
		}
	}
	condition = {
		tooltip = "ab_andalusian_civil_war_cant_stab"
		potential = {
			tag = ADU
		}
		allow = {
			OR = {
				has_country_flag = had_andalusian_civil_war
				has_disaster = andalusian_civil_war
			}
		}
	}
}
```