### PR TITLE
effects: add set_defender_of_the_faith from 1.32

### DIFF
--- a/effects.cwt
+++ b/effects.cwt
@@ -3609,3 +3609,17 @@ alias[effect:add_years_of_estate_land_income] = float
 ## scope = country
 ###Removes a hired advisor of a monarch power type for the current scope. Does not fire on_action for advisor being fired.
 alias[effect:remove_advisor_by_category_no_action] = enum[power_categories]
+
+## scope = country
+###Sets the country as defender of the faith, overriding the existing defender if it exists.
+alias[effect:set_defender_of_the_faith] = {
+	## cardinality = 1..1
+	who = scope[country]
+	## cardinality = 1..1
+	who = enum[country_tags]
+
+	## cardinality = 0..1
+	religion = scope[country]
+	## cardinality = 0..1
+	religion = enum[country_tags]
+}


### PR DESCRIPTION
This is based on my experiments but there is simply no documentation for what the "who" and "religion" do, "who" is simply enough the country that will be set as the defender of the faith

I could not figure out what "religion =" does so I just went with the only information that exists of this effect which is that it accepts a <tag>, I also made it accepts a country scope because the Ante Bellum code uses it with no apparent ill-effect
