### PR TITLE
greatprojects: make country_modifiers optional

### DIFF
--- a/common/greatprojects.cwt
+++ b/common/greatprojects.cwt
@@ -107,6 +107,7 @@ great_project = {
 			alias_name[modifier] = alias_match_left[modifier]
 		}
 		## replace_scope = { root = country this = country }
+		## cardinality = 0..1
 		country_modifiers = {
 			alias_name[modifier] = alias_match_left[modifier]
 		}


### PR DESCRIPTION
some new monuments added in 1.34 do not have it
