### PR TITLE
effects: tooltip push into any scope

### DIFF
--- a/scope_links.cwt
+++ b/scope_links.cwt
@@ -187,6 +187,7 @@ alias[trigger:<trade_company>] = {
 
 
 ## scope = any
+## push_scope = any
 ###The enclosed effects will be displayed in tooltips but not executed
 alias[effect:tooltip] = {
 	alias_name[effect] = alias_match_left[effect]


### PR DESCRIPTION
this is necessary as vanilla now uses it with different scopes, intentionally (this is the important factor), to create nicer tooltips for the end user. It would be unfair to push false-positive errors onto the user, at least more unfair than not providing proper scope-checking inside tooltip

closes #177
