### PR TITLE
add support for custom localisation commands

### DIFF
--- a/customizable_localisation/custom_locs.cwt
+++ b/customizable_localisation/custom_locs.cwt
@@ -1,4 +1,13 @@
 
+enums = {
+	complex_enum[custom_loc_commands] = {
+		path = "game/customizable_localization"
+		name = {
+			name = scalar
+		}	
+	}
+}
+
 types = {
 	type[custom_loc] = {
 		path = "game/customizable_localization"

--- a/localisation.cwt
+++ b/localisation.cwt
@@ -70,4 +70,5 @@ localisation_commands = {
 	GetParliamentWithGrammer = country
 	Leader = unit
 	Location = unit
+	enum[custom_loc_commands] = any
 }


### PR DESCRIPTION
closes #233

Example text

```
#eng_rule_waves
defined_text = {
	name = eng_rule_waves_bonus_ang
	random = no

	text = {
		localisation_key = AB_yes
		trigger = {
			tag = ANG
		}
	}
	text = {
		localisation_key = AB_no
	}
}
```

the custom localisation command `[eng_rule_waves_bonus_ang]` should be made available.