### PR TITLE
effects: add support for add_institution_embracement_scaled

### DIFF
--- a/effects.cwt
+++ b/effects.cwt
@@ -3809,3 +3809,7 @@ alias[effect:change_national_focus] = none
 ## scope = country
 ###Generates an agenda for the specified estate, which can then be started with start_estate_agenda = <estate>
 alias[effect:generate_estate_agenda] = <estate>
+
+## scope = province
+###Adds embracement of an institution based on the development of the province, up to 10% embracement.
+alias[effect:add_next_institution_embracement_scaled] = int[-10..10]


### PR DESCRIPTION
I have decided to keep it between values of -10 and 10 because that is the maximum amount of embracement that the effect gives after scaling for the province's development, so even if you pass "100" to the effect it will just increase 10, and the minimum it can increase is 1.33 if the province has 1/1/1 development
