### PR TITLE
for_variable_amount: use correct value

### DIFF
--- a/common/scripted_triggers_and_effects.cwt
+++ b/common/scripted_triggers_and_effects.cwt
@@ -1,7 +1,7 @@
 
 types = {
 	# Add scripted triggers that we support explicitly below
-	## type_key_filter <> { has_reached_government_reform_tier has_completed_idea_group_of_category }
+	## type_key_filter <> { has_completed_idea_group_of_category }
 	type[scripted_trigger] = {
 		path = "game/common/scripted_triggers"
 	}
@@ -55,21 +55,6 @@ alias[effect:unlock_merc_company] = {
 	merc_company = <mercenary_company>
 	## cardinality = 0..1
 	free_merc = yes
-}
-
-## scope = country
-### Forced scripted trigger to work
-alias[trigger:has_reached_government_reform_tier] = {
-	## cardinality = 0..1
-	tier_2 = yes
-	## cardinality = 0..1
-	tier_3 = yes
-	## cardinality = 0..1
-	tier_4 = yes
-	## cardinality = 0..1
-	tier_5 = yes
-	## cardinality = 0..1
-	tier_6 = yes
 }
 
 ## replace_scope = { this = country root = country }

--- a/common/scripted_triggers_and_effects.cwt
+++ b/common/scripted_triggers_and_effects.cwt
@@ -102,7 +102,7 @@ alias[effect:unlock_estate] = {
 ###Forced scripted effect to work
 alias[effect:for_variable_amount] = {
 	## cardinality 0..1
-	variable = election_term
+	variable = value[variable]
 	## cardinality 0..1
 	effect = scalar
 }

--- a/common/scripted_triggers_and_effects.cwt
+++ b/common/scripted_triggers_and_effects.cwt
@@ -1,8 +1,12 @@
 
 types = {
+	# Add scripted triggers that we support explicitly below
+	## type_key_filter <> { has_reached_government_reform_tier has_completed_idea_group_of_category }
 	type[scripted_trigger] = {
 		path = "game/common/scripted_triggers"
 	}
+	# Add scripted effets that we support explicitly below
+	## type_key_filter <> { add_latest_building unlock_merc_company kill_advisor_by_category_effect unlock_estate for_variable_amount show_points_needed_for_livionian_government_of_category count_won_battles_and_reward_at_end faction_in_power_effect }
 	type[scripted_effect] = {
 		path = "game/common/scripted_effects"
 	}


### PR DESCRIPTION
Make so the keys that we explicitly define are removed from the auto-generation, this removes duplicate results and provides better results.

Before:

![image](https://user-images.githubusercontent.com/30738253/214463053-547b8f9d-31e8-41da-869c-8b2f40deb845.png)

---

After:

![image](https://user-images.githubusercontent.com/30738253/214463138-d60607ae-8afe-4b77-adf4-348dff2bb01d.png)
