### PR TITLE
allow more than 9 age objectives

### DIFF
--- a/common/ages.cwt
+++ b/common/ages.cwt
@@ -54,7 +54,7 @@ game_age = {
 	}
 	
 	objectives = {
-		## cardinality = 4..9
+		## cardinality = 4..inf
 		## replace_scope = { root = country this = country }
 		localisation = {
 			## cardinality = 0..1


### PR DESCRIPTION
We have then in Ante Bellum, they use the 'allow = { }' block that hides the objective if you do not meet the requirements
