### PR TITLE
Add rebel type progress fix

### DIFF
--- a/effects.cwt
+++ b/effects.cwt
@@ -3914,7 +3914,7 @@ alias[effect:add_random_development] = int
 alias[effect:add_rebel_progress] = {
 	value = int
 	## cardinality = 0..1
-	type = <rebel_type>
+	rebel_type = <rebel_type>
 }
 
 ## scope = country


### PR DESCRIPTION
A typo in add_rebel_progress

>   - Added add_rebel_progress = { (rebel_type = <rebel type>) value = <int> } #Add rebel progress to a specified rebel type. If no rebel type is defined then add progress to all rebels.

![Screenshot (29)](https://github.com/cwtools/cwtools-eu4-config/assets/40493835/17bc3299-6508-4380-8dc6-65ee52733478)

