### PR TITLE
Fix for global event target loc warnings

### DIFF
--- a/effects.cwt
+++ b/effects.cwt
@@ -107,11 +107,11 @@ alias[effect:save_event_target_as] = value_set[event_target]
 
 ## scope = any
 ###Saves the current scope as a key to be used in further effects/triggers and in localisations. Is NOT cleared once execution ends, but rather is kept until cleared with clear_global_event_target. Use event_target:<key> to access the scope.
-alias[effect:save_global_event_target_as] = value_set[global_event_target]
+alias[effect:save_global_event_target_as] = value_set[event_target]
 
 ## scope = any
 ###Clears a specific global event target.
-alias[effect:clear_global_event_target] = value[global_event_target]
+alias[effect:clear_global_event_target] = value[event_target]
 
 ## scope = any
 ###Clears all global event targets.


### PR DESCRIPTION
A fix for loc error with global_event_targets (like Emperor). They are actually called through event_target in code.

![Screenshot (33)](https://github.com/cwtools/cwtools-eu4-config/assets/40493835/6f0831a4-decc-488d-96f8-57e7446f8471)
