### PR TITLE
Added triggered faction name

### DIFF
--- a/common/00_small_types_consolidated.cwt
+++ b/common/00_small_types_consolidated.cwt
@@ -184,6 +184,15 @@ faction = {
 	modifier = {
 		alias_name[modifier] = alias_match_left[modifier]
 	}
+
+	## cardinality = 0..1
+	triggered_faction_name = {
+		name = scalar
+
+		trigger = {
+			alias_name[trigger] = alias_match_left[trigger]
+		}
+	}
 }
 
 


### PR DESCRIPTION
Factions can have one triggered_faction_name.

![Screenshot (34)](https://github.com/cwtools/cwtools-eu4-config/assets/40493835/f6228817-f854-4725-afd7-02ba6d00a0b2)
