### PR TITLE
Allow alternative version of check variable without using which or value

### DIFF
--- a/triggers.cwt
+++ b/triggers.cwt
@@ -364,9 +364,12 @@ alias[trigger:cavalry_in_province] = enum[country_tags]
 ## scope = { province country }
 ###Returns true if the specified variable is at least X.
 alias[trigger:check_variable] = {
-	## cardinality = 1..2
+	## cardinality = 0..2
 	## severity = warning
 	which = value[variable]
+	## cardinality = 0..2
+	## severity = warning
+	value[variable]= float
 	## cardinality = 0..1
 	value = float
 }


### PR DESCRIPTION
check_variable = { consort_adm_var = 12 }