### PR TITLE
Missing rebel government

### DIFF
--- a/common/rebel_types.cwt
+++ b/common/rebel_types.cwt
@@ -59,6 +59,7 @@ enums = {
 		theocracy
 		anti
 		any
+		tribal
 	}
 	enum[rebel_defection] = {
 		culture


### PR DESCRIPTION
I found a government type missing in rebel_governments. Probably u can actually change it to `<government>` or smth.