### PR TITLE
Optional dlc check in incidents

### DIFF
--- a/common/incidents.cwt
+++ b/common/incidents.cwt
@@ -19,10 +19,6 @@ incident = {
 
 	## replace_scopes = { this = country root = country }
 	potential = {
-		###Fair use check
-		## cardinality = 0..1
-		has_dlc = "Mandate of Heaven"
-		
 		alias_name[trigger] = alias_match_left[trigger]
 	}
 

--- a/common/incidents.cwt
+++ b/common/incidents.cwt
@@ -20,7 +20,9 @@ incident = {
 	## replace_scopes = { this = country root = country }
 	potential = {
 		###Fair use check
+		## cardinality = 0..1
 		has_dlc = "Mandate of Heaven"
+		
 		alias_name[trigger] = alias_match_left[trigger]
 	}
 


### PR DESCRIPTION
This check is useless, as u can't have shinto incidents without dlc anyway. Probably can be removed if `alias_name[trigger] = alias_match_left[trigger]` can include `has_dlc` trigger