### PR TITLE
Missing things in gov reform conditionals

### DIFF
--- a/common/governments_and_reforms.cwt
+++ b/common/governments_and_reforms.cwt
@@ -546,18 +546,7 @@ government_reform = {
 		## cardinality = 0..inf
 		conditional = {
 			allow = {
-				## cardinality = 0..inf
-				has_dlc = enum[DLCs]
-				## cardinality = 0..inf
-				NOT = {
-					## cardinality = 0..inf
-					has_dlc = enum[DLCs]
-				}
-				## cardinality = 0..inf
-				OR = {
-					## cardinality = 0..inf
-					has_dlc = enum[DLCs]
-				}
+				alias_name[trigger] = alias_match_left[trigger]
 			}
 			## cardinality = 0..1
 			allow_carolean = bool
@@ -672,6 +661,24 @@ government_reform = {
 				can_remove_idea_group = bool
 				## cardinality = 0..1
 				mercs_do_not_cost_army_professionalism = bool
+			}
+		
+			## cardinality = 0..1
+			nomad = bool
+			## cardinality = 0..1
+			native_mechanic = bool
+			## cardinality = 0..1
+			allow_force_tributary = bool
+			## cardinality = 0..1
+			uses_revolutionary_zeal = bool
+			## cardinality = 0..1
+			boost_income = bool
+			## cardinality = 0..1
+			is_trading_city = bool
+
+			## cardinality = 0..1
+			modifiers = {
+				alias_name[modifier] = alias_match_left[modifier]
 			}
 		}
 


### PR DESCRIPTION
A few things that I found missing in government reform conditional:
1. `allow` block can have any trigger, not just `has_dlc`
2. A few options like `nomad`, `native_mechanic` and `modifiers` are missing. 

Also about those missing options - maybe there is away to avoid duplicating lines by moving them somewhere? Like we use `alias_name[modifier] = alias_match_left[modifier]` , so it could be `alias_name[government_modifier] = alias_match_left[government_modifier]` or smth. I'm sure there are more missing options, that would solve that in the future.