### PR TITLE
Remove non bracket kill_leader rules

### DIFF
--- a/effects.cwt
+++ b/effects.cwt
@@ -1058,18 +1058,6 @@ alias[effect:kill_leader] = {
 	type = localisation_synced #value[leader_name]
 }
 
-## scope = { country province }
-###In country scope, kills a leader held by the current scope matching the type used. Format: kill_leader = { type = general/random/name }. In province scope, kills a leader in the current province scope if they match the type used. Format: kill_leader = general/random/name Only works if the leader is assigned to a unit that is stationed in the current province.
-alias[effect:kill_leader] = enum[military_leader_types]
-
-## scope = { country province }
-###In country scope, kills a leader held by the current scope matching the type used. Format: kill_leader = { type = general/random/name }. In province scope, kills a leader in the current province scope if they match the type used. Format: kill_leader = general/random/name Only works if the leader is assigned to a unit that is stationed in the current province.
-alias[effect:kill_leader] = random
-
-## scope = { country province }
-###In country scope, kills a leader held by the current scope matching the type used. Format: kill_leader = { type = general/random/name }. In province scope, kills a leader in the current province scope if they match the type used. Format: kill_leader = general/random/name Only works if the leader is assigned to a unit that is stationed in the current province.
-alias[effect:kill_leader] = localisation_synced #value[leader_name]
-
 ## scope = country
 ###Creates an admiral with the defined attributes for the current scope. Leader traits can be found in /Europa Universalis IV/common/leader_personalities/*.txt. Siege improves Blockade Efficiency for admirals. The name parameter can accept a saved name variable, see set_saved_name for more context.
 alias[effect:define_admiral] = {


### PR DESCRIPTION
All vanilla uses bracketed version, and from what i've seen using the non bracket one won't cause verbal error log, but instead cause way harder to track bracket error