### PR TITLE
Gov reform fixes

### DIFF
--- a/common/governments_and_reforms.cwt
+++ b/common/governments_and_reforms.cwt
@@ -486,6 +486,13 @@ government_reform = {
 		has_cultural_union = bool
 
 		## cardinality = 0..1
+		allow_banners = bool
+		## cardinality = 0..1
+		has_meritocracy = bool
+		## cardinality = 0..1
+		trade_city_reform = <government_reform>
+
+		## cardinality = 0..1
 		replacement_on_independence_war = <government_reform.new>
 
 		## replace_scope = { root = country this = country }

--- a/common/governments_and_reforms.cwt
+++ b/common/governments_and_reforms.cwt
@@ -285,7 +285,10 @@ government_reform = {
 		heirs_can_be_generals = bool
 		fixed_rank = int
 		republican_name = bool
-		government_abilities = { }
+		government_abilities = {
+			## cardinality = 0..inf
+			<government_mechanic>
+		}
 		claim_states = bool
 		religion = bool
 		republic = bool


### PR DESCRIPTION
I have two additions to gov reform rules:
1. U can add gov abilities to default reform, so everyone will have them
2. There are few missing modifiers (they are added in default and conditional, but missing in reform body). These are the ones I noticed - `allow_banners `, `has_meritocracy ` and `trade_city_reform`