### PR TITLE
[1.36] Optional scaled with gain modifier

### DIFF
--- a/effects.cwt
+++ b/effects.cwt
@@ -380,6 +380,7 @@ alias[effect:add_government_power] = {
 	mechanic_type = <government_mechanic>
 	power_type = <government_mechanic_power>
 	value = float
+	## cardinality = 0..1
 	scaled_with_gain_modifier = bool
 }
 
@@ -415,6 +416,7 @@ alias[effect:add_government_power_scaled_to_seats] = {
 	mechanic_type = <government_mechanic>
 	power_type = <government_mechanic_power>
 	value = int
+	## cardinality = 0..1
 	scaled_with_gain_modifier = bool
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/cwtools/cwtools-eu4-config/commit/4936629b2cc71da5beae95bd23dc8a8d523b8a2d - it's an optional setting, so should have cardinality