### PR TITLE
Subject view classes

### DIFF
--- a/common/subject_types.cwt
+++ b/common/subject_types.cwt
@@ -219,13 +219,13 @@ subject_type = {
 	military_focus = float
 	## cardinality = 0..1
 	###relative_power_class decides how Subjects are grouped together when considering relative strenghth towards overlord: If it is 0 they won't consider relative power and if it is 1 they will only consider their own power (and those supporting their independence) compared to their Overlord's. Otherwise they will sum up the power of every Subject of the same relative_power_class as themselves, and all countries who support either themselves or one of their allies in the same relative_power_class.
-	relative_power_class = int[0..2]
+	relative_power_class = int
 	## cardinality = 0..1
 	should_quit_wars_on_activation = bool
 
 	## cardinality = 0..1
 	###diplomacy_view_class decides how subjects are grouped together in diplomacy view and in foreign province view: 0 means it won't be listed, 1 means it will be listed together only with the same subject type. Other values means it will be listed together with all subjects of the same diplomacy_view_class
-	diplomacy_view_class = int[0..2]
+	diplomacy_view_class = int
 	
 	## cardinality = 0..1
 	##replace_scope = { root = country this = country from = country }


### PR DESCRIPTION
>relative_power_class decides how Subjects are grouped together when considering relative strenghth towards overlord: If it is 0 they won't consider relative power and if it is 1 they will only consider their own power (and those supporting their independence) compared to their Overlord's. **Otherwise they will sum up the power of every Subject of the same relative_power_class as themselves, and all countries who support either themselves or one of their allies in the same relative_power_class.**

> diplomacy_view_class decides how subjects are grouped together in diplomacy view and in foreign province view: 0 means it won't be listed, 1 means it will be listed together only with the same subject type. **Other values means it will be listed together with all subjects of the same diplomacy_view_class**

So u can use other numbers to set up categories.