### PR TITLE
Special units

### DIFF
--- a/effects.cwt
+++ b/effects.cwt
@@ -4313,7 +4313,6 @@ alias[effect:voc_indiamen_light] = enum[country_tags]
 alias[effect:create_unit_forcelimit_percentage] = {
 	###Using a unit type that does not exist will create a unit that when selected will cause a Crash to Desktop
 	type = enum[unit_types]
-	## cardinality = 0..1
 	force_limit_percentage = float
 	## cardinality = 0..1
 	###Does not respect special_unit_category restrictions to a unit type, allowing creation of nonsencial units, for example 'Man of War Infantry', 'Carolean Heavy Frigate', 'Samurai Coehorn Mortar', etc.

--- a/effects.cwt
+++ b/effects.cwt
@@ -4313,6 +4313,7 @@ alias[effect:voc_indiamen_light] = enum[country_tags]
 alias[effect:create_unit_forcelimit_percentage] = {
 	###Using a unit type that does not exist will create a unit that when selected will cause a Crash to Desktop
 	type = enum[unit_types]
+	## cardinality = 0..1
 	force_limit_percentage = float
 	## cardinality = 0..1
 	###Does not respect special_unit_category restrictions to a unit type, allowing creation of nonsencial units, for example 'Man of War Infantry', 'Carolean Heavy Frigate', 'Samurai Coehorn Mortar', etc.

--- a/enums.cwt
+++ b/enums.cwt
@@ -504,7 +504,7 @@ enums = {
 	}
 	# special units
 	enum[special_units] = {
-		banners
+		banner
 		caravel
 		carolean
 		cawa
@@ -514,7 +514,7 @@ enums = {
 		geobukseon
 		janissaries
 		man_of_war
-		mustekeer
+		musketeer
 		rajput
 		revolutionary_guard
 		samurai
@@ -524,7 +524,7 @@ enums = {
 		hussars
 		qizilbash
 		mamluks
-		marine
+		marines
 	}
 	# Special Unit Types, that can be used in create_units_of_type
 	# this list is incomplete, help expand it


### PR DESCRIPTION
1. `create_unit_forcelimit_percentage` has an optional param `force_limit_percentage`
2. `enum[special_units]` has a few typos

Also, a note about `alias[effect:create_unit_forcelimit_percentage]`:
- `type = enum[unit_types]` is a bit wrong, cause u can write `type = aboriginal_ambusher` and it'll create one. I leave it for your consideration, if u want to fix it outside of this PR