### PR TITLE
Cardinality and Comment info for tooltips in custom GUI elements

### DIFF
--- a/common/custom_gui.cwt
+++ b/common/custom_gui.cwt
@@ -41,6 +41,8 @@ custom_button = {
 		alias_name[effect] = alias_match_left[effect]
 	}
 	###Tooltip to display while hovering this button. Not required, but highly recommended.
+	## cardinality = 1..1
+	## severity = warning
 	tooltip = localisation
 	## cardinality = 0..inf
 	###Which frame file to use

--- a/common/custom_gui.cwt
+++ b/common/custom_gui.cwt
@@ -40,8 +40,7 @@ custom_button = {
 	effect = {
 		alias_name[effect] = alias_match_left[effect]
 	}
-	## cardinality = 0..1
-	###Tooltip to display while hovering this element
+	###Tooltip to display while hovering this button. Not required, but highly recommended.
 	tooltip = localisation
 	## cardinality = 0..inf
 	###Which frame file to use
@@ -63,7 +62,7 @@ custom_text_box = {
 		alias_name[trigger] = alias_match_left[trigger]
 	}
 	## cardinality = 0..1
-	###Tooltip to display while hovering this element
+	###Tooltip to display while hovering this text. Optional.
 	tooltip = localisation
 }
 
@@ -75,7 +74,7 @@ custom_icon = {
 		alias_name[trigger] = alias_match_left[trigger]
 	}
 	## cardinality = 0..1
-	###Tooltip to display while hovering this element
+	###Tooltip to display while hovering this icon. Optional.
 	tooltip = localisation
 	## cardinality = 0..inf
 	###Which frame file to use
@@ -105,7 +104,7 @@ custom_shield = {
 		alias_name[effect] = alias_match_left[effect]
 	}
 	## cardinality = 0..1
-	###Tooltip to display while hovering this element
+	###Tooltip to display while hovering this shield. Optional.
 	tooltip = localisation
 	###Global event target name
 	global_event_target = <country_event>

--- a/common/custom_gui.cwt
+++ b/common/custom_gui.cwt
@@ -40,6 +40,8 @@ custom_button = {
 	effect = {
 		alias_name[effect] = alias_match_left[effect]
 	}
+	## cardinality = 0..1
+	###Tooltip to display while hovering this element
 	tooltip = localisation
 	## cardinality = 0..inf
 	###Which frame file to use
@@ -60,6 +62,8 @@ custom_text_box = {
 	potential = {
 		alias_name[trigger] = alias_match_left[trigger]
 	}
+	## cardinality = 0..1
+	###Tooltip to display while hovering this element
 	tooltip = localisation
 }
 
@@ -70,6 +74,8 @@ custom_icon = {
 	potential = {
 		alias_name[trigger] = alias_match_left[trigger]
 	}
+	## cardinality = 0..1
+	###Tooltip to display while hovering this element
 	tooltip = localisation
 	## cardinality = 0..inf
 	###Which frame file to use
@@ -98,6 +104,8 @@ custom_shield = {
 	effect = {
 		alias_name[effect] = alias_match_left[effect]
 	}
+	## cardinality = 0..1
+	###Tooltip to display while hovering this element
 	tooltip = localisation
 	###Global event target name
 	global_event_target = <country_event>


### PR DESCRIPTION
This PR adds comments to the tooltip entries for each custom GUI element, as well as cardinality info.

All tooltips are technically optional, but custom buttons will raise a warning if a tooltip is not present for UX reasons.