### PR TITLE
Fixed bug with custom shields

### DIFF
--- a/common/custom_gui.cwt
+++ b/common/custom_gui.cwt
@@ -109,7 +109,7 @@ custom_shield = {
 	###Tooltip to display while hovering this shield. Optional.
 	tooltip = localisation
 	###Global event target name
-	global_event_target = <country_event>
+	global_event_target = value[global_event_target]
 	###If clicking opens the country view
 	open_country = bool
 }


### PR DESCRIPTION
I'm not 100% sure if this is the correct solution, but it did make this errors go away in my custom gui files. If someone could verify that this is the correct solution, that would be great. My solution was to replace the `<country_event>` portion (no idea what that's meant to do actually) with the RHS from `has_saved_global_event_target` in the triggers file.